### PR TITLE
fix: harden Android build for renderer plugin compatibility

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -27,32 +27,36 @@ jobs:
     - name: Install dependencies
       run: npm ci  # 使用clean install确保依赖一致性
     
-    # 步骤4: 检查Node版本 (调试用)
-    - name: Check Node version
-      run: node --version && npm --version
-    
-    # 步骤5: 设置Java环境 (项目配置要求Java 21)
+    # 步骤4: 设置Java环境 (项目配置要求Java 21)
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'  # 使用Temurin发行版
         java-version: '21'  # Java 21版本
     
-    # 步骤6: 设置Android SDK
+    # 步骤5: 设置Android SDK
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
     
-    # 步骤7: 构建Android APK
+    # 步骤6: 构建Android APK
     - name: Build Android APK
       run: |
-        npx cap sync  # 同步Web资源到Android项目
+        # 仅复制Web资源到原生项目，不执行update逻辑，防止覆盖手动修改的原生配置
+        npx cap copy android  
+        
         cd capacitor-android
-        ./gradlew assembleRelease  # 构建正式版APK
+        
+        # 确保gradle脚本有执行权限
+        chmod +x gradlew
+        
+        # 构建Debug版本。Debug版会自动签名，下载到手机后可以直接安装运行
+        ./gradlew assembleDebug
     
-    # 步骤8: 上传APK作为工作流产物
+    # 步骤7: 上传APK作为工作流产物
     - name: Upload APK artifact
       uses: actions/upload-artifact@v4
       with:
         name: android-apk  # 产物名称
-        path: capacitor-android/app/build/outputs/apk/release/app-release.apk  # 正式版APK文件路径
+        # 路径指向Debug版APK所在位置
+        path: capacitor-android/app/build/outputs/apk/debug/app-debug.apk
         if-no-files-found: error  # 如果找不到文件则报错

--- a/capacitor-android/app/build.gradle
+++ b/capacitor-android/app/build.gradle
@@ -69,7 +69,8 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
+    // 注意：移除了下面这行，因为你的项目不需要Cordova插件
+    // implementation project(':capacitor-cordova-android-plugins')
 }
 
 apply from: 'capacitor.build.gradle'

--- a/capacitor-android/app/build.gradle
+++ b/capacitor-android/app/build.gradle
@@ -1,34 +1,55 @@
 apply plugin: 'com.android.application'
 
 android {
+    // 确保命名空间一致
     namespace = "com.ltw.plugin.renderer.ltw"
-    compileSdk = rootProject.ext.compileSdkVersion
+    
+    // 强制锁定在 API 34 (Android 14)，避开 API 35+ 的 16KB 页对齐限制
+    compileSdk = 34
     
     packagingOptions {
+        // 关键修改：强制解压库文件，这是修复 UnsatisfiedLinkError 的核心
+        jniLibs {
+            useLegacyPackaging = true
+        }
+        // 保持你原有的 pickFirst
         pickFirst "lib/**/libltw_turbo.so"
     }
     
     defaultConfig {
         applicationId "com.ltw.plugin.renderer.ltw"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion 24
+        // 强制锁定 targetSdk 为 34
+        targetSdkVersion 34
+        
         versionCode 1
         versionName "1.0"
+        
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        
         ndk {
+            // 确保只打包这四种架构，减少 APK 体积
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
+        
         aaptOptions {
-             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
-             // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
+             // 保持默认配置
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
+        }
+    }
+    
+    // 确保源码集正确指向 jniLibs
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['src/main/jniLibs']
         }
     }
 }

--- a/capacitor-android/app/capacitor.build.gradle
+++ b/capacitor-android/app/capacitor.build.gradle
@@ -7,7 +7,6 @@ android {
   }
 }
 
-apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
 
 

--- a/capacitor-android/app/src/main/AndroidManifest.xml
+++ b/capacitor-android/app/src/main/AndroidManifest.xml
@@ -2,14 +2,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ltw.plugin.renderer.ltw">
 
+    <!-- 显式指定 SDK 版本，建议设为 34 (Android 14) 以获得最佳兼容性 -->
+    <uses-sdk
+        android:minSdkVersion="24"
+        android:targetSdkVersion="34" />
+
+    <!-- 拥有完全的网络访问权限 -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:extractNativeLibs="true"
+        android:appComponentFactory="androidx.core.app.CoreComponentFactory">
 
+        <!-- 启动器插件必要的元数据 -->
         <meta-data android:name="fclPlugin" android:value="true" />
         <meta-data android:name="des" android:value="LTW-Turbo (OpenGL 3.2 and 4.6, All Version)" />
         <meta-data android:name="renderer" android:value="LTW:libltw_turbo.so:libltw_turbo.so" />
@@ -40,7 +51,4 @@
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
     </application>
-
-    <!-- Permissions -->
-    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/capacitor-android/variables.gradle
+++ b/capacitor-android/variables.gradle
@@ -4,14 +4,14 @@ ext {
     compileSdkVersion = 34
     targetSdkVersion = 34
     
-    // 以下版本保持不变，它们与 SDK 34 兼容
-    androidxActivityVersion = '1.11.0'
-    androidxAppCompatVersion = '1.7.1'
-    androidxCoordinatorLayoutVersion = '1.3.0'
-    androidxCoreVersion = '1.17.0'
-    androidxFragmentVersion = '1.8.9'
-    coreSplashScreenVersion = '1.2.0'
-    androidxWebkitVersion = '1.14.0'
+    // 降级到与 SDK 34 兼容的版本（根据错误信息调整）
+    androidxActivityVersion = '1.8.0'          // 从 1.11.0 降级
+    androidxAppCompatVersion = '1.7.1'        // 保持不变
+    androidxCoordinatorLayoutVersion = '1.3.0' // 保持不变
+    androidxCoreVersion = '1.12.0'            // 从 1.17.0 降级
+    androidxFragmentVersion = '1.8.0'         // 从 1.8.9 降级
+    coreSplashScreenVersion = '1.0.2'         // 从 1.2.0 降级
+    androidxWebkitVersion = '1.10.0'          // 从 1.14.0 降级
     junitVersion = '4.13.2'
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'

--- a/capacitor-android/variables.gradle
+++ b/capacitor-android/variables.gradle
@@ -1,7 +1,10 @@
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 36
-    targetSdkVersion = 36
+    // 降回 34 (Android 14)，这是目前对原生库兼容性最好的版本
+    compileSdkVersion = 34
+    targetSdkVersion = 34
+    
+    // 以下版本保持不变，它们与 SDK 34 兼容
     androidxActivityVersion = '1.11.0'
     androidxAppCompatVersion = '1.7.1'
     androidxCoordinatorLayoutVersion = '1.3.0'


### PR DESCRIPTION
- Lock SDK versions to 34 (Android 14) for best native library compatibility
- Add useLegacyPackaging=true and extractNativeLibs=true to fix UnsatisfiedLinkError
- Change CI to build debug APK with cap copy (prevents overwriting native config)
- Explicitly set jniLibs.srcDirs and minSdkVersion
- Update AndroidManifest with proper SDK declarations